### PR TITLE
Firefox でエラーとなる window.parseInt() の呼び出しを parseInt() に置き換える

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -7,8 +7,8 @@ export default class Draggable {
     this.elementY = null;
     document.body.addEventListener("mousemove", e => {
       if (this.targetElement) {
-        let x = this.parseInt(e.pageX, 10);
-        let y = this.parseInt(e.pageY, 10);
+        let x = this.parseInt(e.pageX);
+        let y = this.parseInt(e.pageY);
         let left = this.elementX + x - this.startingX;
         let top = this.elementY + y - this.startingY;
         this.targetElement.style.left = left.toString() + "px";
@@ -33,8 +33,8 @@ export default class Draggable {
     titleBar.addEventListener("mousedown", e => {
       this.targetElement = elem;
       this.targetElement.style.opacity = 0.35;
-      this.startingX = this.parseInt(e.pageX, 10);
-      this.startingY = this.parseInt(e.pageY, 10);
+      this.startingX = this.parseInt(e.pageX);
+      this.startingY = this.parseInt(e.pageY);
       this.elementX = this.parseInt(this.targetElement.style.left);
       this.elementY = this.parseInt(this.targetElement.style.top);
     });
@@ -45,7 +45,7 @@ export default class Draggable {
     if (str === null || str === undefined || str === "") {
       r = 0;
     } else {
-      r = window.parseInt(str, 10);
+      r = parseInt(str, 10);
       if (isNaN(r)) {
         r = 0;
       }


### PR DESCRIPTION
Firefox 63 で確認したところ Firefox では拡張機能からグローバル関数の parseInt() は window.parseInt() として呼び出すことができないようです(TypeError: window.parseInt is not a function エラーとなる)。
実際 parseInt() の方が標準だと思いますので、 window.parseInt() となっているところを parseInt() に置き換え、ついでに Draggable#parseInt 呼び出しには不要な引数の削除も行っています。