### PR TITLE
Use Document.caretPositionFromPoint() when available instead of Document.caretRangeFromPoint() (for supporting Firefox)

### DIFF
--- a/src/atcursor.js
+++ b/src/atcursor.js
@@ -2,13 +2,11 @@ export default (element, clientX, clientY) => {
   let textOnCursor = null;
 
   try {
-    const range = element.ownerDocument.caretRangeFromPoint(clientX, clientY);
+    const range = getCaretNodeAndOffsetFromPoint(element.ownerDocument, clientX, clientY);
     if (range) {
-      const container = range.startContainer;
-      const startOffset = range.startOffset;
-
-      if (container.nodeType == Node.TEXT_NODE) {
-        textOnCursor = getTextFromRange(container.data, startOffset);
+      const { node, offset } = range;
+      if (node.nodeType === Node.TEXT_NODE) {
+        textOnCursor = getTextFromRange(node.data, offset);
       }
     }
   } catch (err) {
@@ -71,4 +69,26 @@ const getTextFromRange = (text, offset) => {
   const endIndex = searchEndIndex(text, offset);
 
   return text.substring(startIndex, endIndex);
+};
+
+const getCaretNodeAndOffsetFromPoint = (ownerDocument, pointX, pointY) => {
+  let node = null;
+  let offset = null;
+  if (ownerDocument.caretPositionFromPoint != null) { // for Firefox (based on recent WD of CSSOM View Module)
+    const position = ownerDocument.caretPositionFromPoint(pointX, pointY);
+    if (position) {
+      node = position.offsetNode;
+      offset = position.offset;
+    }
+  } else if (ownerDocument.caretRangeFromPoint != null) { // for Chrome
+    const range = ownerDocument.caretRangeFromPoint(pointX, pointY);
+    if (range) {
+      node = range.startContainer;
+      offset = range.startOffset;
+    }
+  } else {
+    return null;
+  }
+
+  return { node, offset };
 };

--- a/src/atcursor.js
+++ b/src/atcursor.js
@@ -74,21 +74,23 @@ const getTextFromRange = (text, offset) => {
 const getCaretNodeAndOffsetFromPoint = (ownerDocument, pointX, pointY) => {
   let node = null;
   let offset = null;
-  if (ownerDocument.caretPositionFromPoint != null) { // for Firefox (based on recent WD of CSSOM View Module)
+  let result = null;
+
+  if (ownerDocument.caretPositionFromPoint) { // for Firefox (based on recent WD of CSSOM View Module)
     const position = ownerDocument.caretPositionFromPoint(pointX, pointY);
     if (position) {
       node = position.offsetNode;
       offset = position.offset;
+      result = { node, offset };
     }
-  } else if (ownerDocument.caretRangeFromPoint != null) { // for Chrome
+  } else if (ownerDocument.caretRangeFromPoint) { // for Chrome
     const range = ownerDocument.caretRangeFromPoint(pointX, pointY);
     if (range) {
       node = range.startContainer;
       offset = range.startOffset;
+      result = { node, offset };
     }
-  } else {
-    return null;
   }
 
-  return { node, offset };
+  return result;
 };


### PR DESCRIPTION
現在キャレット位置のテキスト取得の目的で`Document.caretRangeFromPoint()`が使われていますが、
`Document.caretPositionFromPoint()`が存在するときはそちらを呼ぶようにします。
Firefoxは`Document.caretRangeFromPoint()`のかわりに`Document.caretPositionFromPoint()`を実装しているのでこれはFirefox対応となります。
`Document.caretPositionFromPoint()`を優先してるのは別に私がFirefox贔屓なのとは関係なく、
こちらがW3Cで策定中のCSSOM View ModuleのWDに準拠したものであることを考慮してのものです。

実装に際しては
* https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint のコード例
* 関数名などインタフェースについては
https://github.com/wikimedia/VisualEditor/blob/c573f351366de85d528e51a869166cbfaa14f05f/src/ce/ve.ce.Document.js
の`ve.ce.Document.getNodeAndOffset`の実装

を参考にしています。
