### PR TITLE
Remove unnecessary extension permissions

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -7,7 +7,7 @@
     "page": "options/options.html",
     "open_in_tab": true
   },
-  "permissions": ["storage", "unlimitedStorage", "activeTab", "tabs", "http://*/*", "https://*/*"],
+  "permissions": ["storage", "unlimitedStorage", "activeTab"],
   "background": {
     "scripts": ["background.js"],
     "persistent": false


### PR DESCRIPTION
ユーザーのアクションによって現在のタブに対してjsを実行するだけならば `activeTab` 権限のみで十分なので、不要な権限を削除しました。
- `tabs`
- `http://*/*`
- `https://*/*`

----

[The activeTab permission - Google Chrome](https://developer.chrome.com/extensions/activeTab)


> # The activeTab permission
> 
> The ` activeTab ` permission gives an extension temporary access to the currently active tab when the user *invokes* the extension \- for example by clicking its [browser action](https://developer.chrome.com/extensions/browserAction ''). Access to the tab lasts until the tab is navigated or closed.
> 
> This serves as an alternative for many uses of ` <all_urls> `

----

[chrome.tabs - Google Chrome](https://developer.chrome.com/extensions/tabs)

> The majority of the `chrome.tabs` API can be used without declaring any permission. However, the `"tabs"` permission is required in order to populate the `url`, `title`, and `favIconUrl` properties of `Tab`. 