### PR TITLE
Support Firefox Shortcut

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -17,6 +17,11 @@
     "default_icon": "icon48.png",
     "default_title": "Mouse Dictionary"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "description": "Activate the extension"
+    }
+  },
   "manifest_version": 2,
   "icons": {
     "16": "icon16.png",


### PR DESCRIPTION
Firefoxで起動ショートカットキーの設定ができるようにmanifest.jsonに起動ショートカットを追加しました。

ショートカットに関するマニュアル
https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Special_shortcuts
