### PR TITLE
Return default settings if user settings is disabled

### DIFF
--- a/src/main/config.js
+++ b/src/main/config.js
@@ -16,7 +16,7 @@ const JSON_FIELDS = new Set(["normalDialogStyles", "movingDialogStyles", "hidden
 
 const loadAll = async () => {
   if (env.disableUserSettings) {
-    return {};
+    return { settings: defaultSettings, position: {} };
   }
   const data = await getStoredData([KEY_USER_CONFIG, KEY_LAST_POSITION]);
   const mergedSettings = { ...defaultSettings, ...data[KEY_USER_CONFIG] };


### PR DESCRIPTION
#34 に対する暫定的な解決策のご提案です。
ユーザー設定が読み込めない場面でも、とりあえず既定の設定を返すようにすることで、エラーは回避できる模様でした。
いかがでしょうか？