### PR TITLE
Support for Safari

### DIFF
--- a/.github/workflows/build-safari.yml
+++ b/.github/workflows/build-safari.yml
@@ -1,0 +1,31 @@
+name: Build for Safari
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install codecov
+        run: npm install -g codecov
+      - name: Install Packages
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run release-safari
+      - name: Upload Build as Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist-safari
+          path: dist-safari

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ For Firefox:
 npm run build-firefox
 ```
 
+For Safari:
+
+```sh
+npm run build-safari
+```
+
 
 #### Release build
 
@@ -88,6 +94,12 @@ For Firefox:
 
 ```sh
 npm run release-firefox
+```
+
+For Safari:
+
+```sh
+npm run release-safari
 ```
 
 ### Watch
@@ -104,6 +116,12 @@ For Firefox:
 
 ```sh
 npm run watch-firefox
+```
+
+For Safari:
+
+```sh
+npm run watch-safari
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "build-firefox": "webpack --config webpack.config.firefox.js",
     "watch-firefox": "webpack -w --config webpack.config.firefox.js",
     "release-firefox": "cross-env NODE_ENV=production npm run build-firefox",
-    "package-firefox": "npm run release-firefox && node build_tools/archive.js firefox"
+    "package-firefox": "npm run release-firefox && node build_tools/archive.js firefox",
+    "build-safari": "webpack --config webpack.config.safari.js",
+    "watch-safari": "webpack -w --config webpack.config.safari.js",
+    "release-safari": "cross-env NODE_ENV=production npm run build-safari && yes | xcrun safari-web-extension-converter --force --no-open dist-safari --project-location dist-safari",
+    "package-safari": "npm run release-safari && node build_tools/archive.js safari"
   },
   "dependencies": {
     "deinja": "0.0.3",

--- a/src/main/core/resource.js
+++ b/src/main/core/resource.js
@@ -31,10 +31,15 @@ if (BROWSER === "FIREFOX") {
     "初めに辞書データをロードしてください(拡張のアイコンを右クリック→「拡張機能を管理」→「...」をクリック→「オプション」)";
   resources.en.needToPrepareDict =
     'Please load dictionary data first. Right click on the extension icon, select "Manage Extension", click "…", and select "Options"';
-} else {
+} else if (BROWSER === "CHROME") {
   resources.ja.needToPrepareDict = "初めに辞書データをロードしてください(拡張のアイコンを右クリック→「オプション」)";
   resources.en.needToPrepareDict =
     'Please load dictionary data first. Right click on the extension icon and select "Options"';
+} else {
+  resources.ja.needToPrepareDict =
+    "初めに辞書データをロードしてください(拡張のアイコンを右クリック→「拡張機能」→「設定」)";
+  resources.en.needToPrepareDict =
+    'Please load dictionary data first. Right click on the extension icon, select "Extensions" tab, and select "Preferences"';
 }
 
 const decideLanguage = () => {

--- a/webpack.config.safari.js
+++ b/webpack.config.safari.js
@@ -1,0 +1,26 @@
+const path = require("path");
+const DefinePlugin = require("webpack/lib/DefinePlugin");
+const commonConfig = require("./webpack.config");
+
+const specificConfig = Object.assign({}, commonConfig);
+
+// Use chrome settings
+
+specificConfig.output = {
+  path: __dirname + "/dist-safari",
+};
+
+specificConfig.plugins.push(
+  new DefinePlugin({
+    BROWSER: JSON.stringify("SAFARI"),
+    DIALOG_ID: JSON.stringify("____MOUSE_DICTIONARY_cf744bd007850b04601dc865815ec0f5e60c6970"),
+  })
+);
+
+specificConfig.resolve.alias = {
+  ponyfill$: path.resolve(__dirname, "src/main/lib/ponyfill/chrome"),
+};
+
+specificConfig.module.rules[0].use.options.configFile = __dirname + "/.babelrc.chrome.json";
+
+module.exports = specificConfig;


### PR DESCRIPTION
This PR brings support of Safari by using [`safari-web-extension-converter`](https://developer.apple.com/documentation/safariservices/safari_web_extensions/converting_a_web_extension_for_safari).  If you have macOS PC, you can release it on [App Store](https://apps.apple.com/us/story/id1377753262); also, [this article]() might be useful for you if you are highly motivated to do that. I would appreciate it if you could do that. If you do not want because of Apple Developer Program, I would like to install this as a Safari Web Extension personally, and I think README.md should be updated.

Moreover, one thing that you should know is that Safari has less storage than the other browsers even though you specified `unlimitedStorage` in [manifest.json](https://github.com/wtetsu/mouse-dictionary/blob/e596dd44bf0a654ed889beeb476b31dd20a5e787/static/manifest.json#L11). Apple states the local storage limit is 5 MB, and unlimited storage permission increases limit to 10 MB ([ref](https://developer.apple.com/documentation/safariservices/safari_web_extensions/assessing_your_safari_web_extension_s_browser_compatibility#3584139)). However, this storage is so few that large-size dictionaries like `EIJIRO-1448` could not have been loaded due to storage quota exceed.

regarding to: #25