### PR TITLE
複数の辞書データを入れたときに見出し語が上書きされてしまい同時に表示されない問題に対処

### DIFF
--- a/src/main/core/generator.js
+++ b/src/main/core/generator.js
@@ -63,10 +63,11 @@ export default class Generator {
       if (typeof desc !== "string") {
         continue;
       }
+      const wordWithoutSuffix = word.split(/_\d+/)[0];
       data.push({
-        head: escapeHtml(word),
+        head: escapeHtml(wordWithoutSuffix),
         desc: this.createDescriptionHtml(desc),
-        isShort: word.length <= shortWordLength,
+        isShort: wordWithoutSuffix.length <= shortWordLength,
         shortDesc: desc.substring(0, this.cutShortWordDescription),
         isFirst: false,
         isLast: false,

--- a/src/main/core/generator.js
+++ b/src/main/core/generator.js
@@ -63,11 +63,10 @@ export default class Generator {
       if (typeof desc !== "string") {
         continue;
       }
-      const wordWithoutSuffix = word.split(/_\d+/)[0];
       data.push({
-        head: escapeHtml(wordWithoutSuffix),
+        head: escapeHtml(word),
         desc: this.createDescriptionHtml(desc),
-        isShort: wordWithoutSuffix.length <= shortWordLength,
+        isShort: word.length <= shortWordLength,
         shortDesc: desc.substring(0, this.cutShortWordDescription),
         isFirst: false,
         isLast: false,

--- a/src/main/core/generator.js
+++ b/src/main/core/generator.js
@@ -28,6 +28,8 @@ export default class Generator {
     // Since contentTemplate is executed fairly frequently,
     // Generator uses this compiled result repeatedly.
     this.compiledContentTemplate = Hogan.compile(settings.contentTemplate);
+
+    this.useMultipleDictionaries = settings.useMultipleDictionaries;
   }
 
   generate(words, descriptions, enableShortWordLength = true) {
@@ -46,7 +48,15 @@ export default class Generator {
   }
 
   createDescriptionHtml(sourceText) {
-    let result = sourceText;
+    let result;
+    if (this.useMultipleDictionaries && sourceText.slice(0, 2) === '{"') {
+      const descriptions = JSON.parse(sourceText);
+      result = Object.entries(descriptions)
+        .map(([lang, desc]) => `[${lang}]\n${desc}`)
+        .join("\n\n");
+    } else {
+      result = sourceText;
+    }
     for (let i = 0; i < this.compiledReplaceRules.length; i++) {
       const rule = this.compiledReplaceRules[i];
       result = result.replace(rule.search, rule.replace);

--- a/src/main/core/lookuper.js
+++ b/src/main/core/lookuper.js
@@ -13,8 +13,6 @@ import utils from "../lib/utils";
 
 const TEXT_LENGTH_LIMIT = 128;
 
-const KEY_DICTIONARY_ID = "**** dictionary_id ****";
-
 export default class Lookuper {
   constructor(settings, doUpdateContent) {
     this.lookupWithCapitalized = settings.lookupWithCapitalized;
@@ -140,13 +138,8 @@ export default class Lookuper {
 }
 
 const fetchDescriptions = async (entries, reForReferences) => {
-  const dictionaryId = (await storage.sync.get(KEY_DICTIONARY_ID))[KEY_DICTIONARY_ID];
-  let entriesWithSuffix = [];
-  for (let suffix = 0; suffix < dictionaryId; suffix++) {
-    entriesWithSuffix = entriesWithSuffix.concat(entries.map((entry) => `${entry}_${suffix}`));
-  }
-  const primaryDescriptions = await storage.local.get(entriesWithSuffix);
-  const primaryHeads = entriesWithSuffix.filter((e) => primaryDescriptions[e]);
+  const primaryDescriptions = await storage.local.get(entries);
+  const primaryHeads = entries.filter((e) => primaryDescriptions[e]);
 
   const refHeads = pickOutRefs(primaryDescriptions, reForReferences);
   if (refHeads.length === 0) {

--- a/src/main/core/lookuper.js
+++ b/src/main/core/lookuper.js
@@ -13,6 +13,8 @@ import utils from "../lib/utils";
 
 const TEXT_LENGTH_LIMIT = 128;
 
+const KEY_DICTIONARY_ID = "**** dictionary_id ****";
+
 export default class Lookuper {
   constructor(settings, doUpdateContent) {
     this.lookupWithCapitalized = settings.lookupWithCapitalized;
@@ -138,8 +140,13 @@ export default class Lookuper {
 }
 
 const fetchDescriptions = async (entries, reForReferences) => {
-  const primaryDescriptions = await storage.local.get(entries);
-  const primaryHeads = entries.filter((e) => primaryDescriptions[e]);
+  const dictionaryId = (await storage.sync.get(KEY_DICTIONARY_ID))[KEY_DICTIONARY_ID];
+  let entriesWithSuffix = [];
+  for (let suffix = 0; suffix < dictionaryId; suffix++) {
+    entriesWithSuffix = entriesWithSuffix.concat(entries.map((entry) => `${entry}_${suffix}`));
+  }
+  const primaryDescriptions = await storage.local.get(entriesWithSuffix);
+  const primaryHeads = entriesWithSuffix.filter((e) => primaryDescriptions[e]);
 
   const refHeads = pickOutRefs(primaryDescriptions, reForReferences);
   if (refHeads.length === 0) {

--- a/src/main/settings.js
+++ b/src/main/settings.js
@@ -13,6 +13,7 @@ export default {
   scroll: "scroll",
   skipPdfConfirmation: false,
   pdfUrl: "",
+  useMultipleDictionaries: false,
   backgroundColor: "#ffffff",
   headFontColor: "#000088",
   descFontColor: "#101010",

--- a/src/options/component/organism/AdvancedSettings.tsx
+++ b/src/options/component/organism/AdvancedSettings.tsx
@@ -20,6 +20,7 @@ export const AdvancedSettings: React.VFC<AdvancedSettingsProps> = (props) => {
   const lookupWithCapitalized = props.settings?.lookupWithCapitalized ?? false;
   const parseWordsLimit = props.settings?.parseWordsLimit ?? 8;
   const pdfUrl = props.settings?.pdfUrl ?? "";
+  const useMultipleDictionaries = props.settings?.useMultipleDictionaries ?? false;
   const contentWrapperTemplate = props.settings?.contentWrapperTemplate ?? "";
   const dialogTemplate = props.settings?.dialogTemplate ?? "";
   const contentTemplate = props.settings?.contentTemplate ?? "";
@@ -70,6 +71,15 @@ export const AdvancedSettings: React.VFC<AdvancedSettingsProps> = (props) => {
           style={{ width: 600 }}
           placeholder="\.pdf$"
         />
+        <label>
+          {res.get("useMultipleDictionaries")}
+          <input
+            type="checkbox"
+            onChange={(e) => update({ useMultipleDictionaries: e.target.checked })}
+            checked={useMultipleDictionaries}
+          />
+        </label>
+        <span>{res.get("useMultipleDictionariesDescription")}</span>
         <h3>
           {res.get("htmlTemplate")}
           <a

--- a/src/options/logic/dict.ts
+++ b/src/options/logic/dict.ts
@@ -44,7 +44,10 @@ type HeadWord = {
   desc: string;
 };
 
+const KEY_DICTIONARY_ID = "**** dictionary_id ****";
+
 export const load = async (loadParam: LoadParam, callback: Callback): Promise<number> => {
+  const dictionaryId = (await storage.sync.get({ [KEY_DICTIONARY_ID]: 0 }))[KEY_DICTIONARY_ID];
   const fileContent = await readAsText(loadParam.file, loadParam.encoding, (e) => {
     callback({ name: "reading", loaded: e.loaded, total: e.total });
   });
@@ -60,7 +63,8 @@ export const load = async (loadParam: LoadParam, callback: Callback): Promise<nu
     if (!hd) {
       continue;
     }
-    dictData[hd.head] = hd.desc;
+    const headWithSuffix = `${hd.head}_${dictionaryId}`;
+    dictData[headWithSuffix] = hd.desc;
     wordCount += 1;
     if (wordCount === 1 || (wordCount > 1 && wordCount % env.get().registerRecordsAtOnce === 0)) {
       callback({ name: "loading", count: wordCount, word: hd });
@@ -72,10 +76,13 @@ export const load = async (loadParam: LoadParam, callback: Callback): Promise<nu
 
   const lastData = parser.flush();
   if (lastData) {
-    Object.assign(dictData, lastData);
+    for (const [head, desc] of Object.entries(lastData)) {
+      dictData[`${head}_${dictionaryId}`] = desc;
+    }
     wordCount += Object.keys(lastData).length;
   }
   await storage.local.set(dictData);
+  await storage.sync.set({ [KEY_DICTIONARY_ID]: dictionaryId + 1 });
   return wordCount;
 };
 
@@ -111,14 +118,16 @@ const createDictParser = (format: DictionaryFileFormat) => {
 };
 
 export const registerDefaultDict = async (fnProgress: ProgressCallback): Promise<number> => {
+  const dictionaryId = (await storage.sync.get({ [KEY_DICTIONARY_ID]: 0 }))[KEY_DICTIONARY_ID];
   const dict = (await loadJsonFile("/data/dict.json")) as DictionaryInformation;
   fnProgress(0, "0");
   let wordCount = 0;
   for (let i = 0; i < dict.files.length; i++) {
-    wordCount += await registerDict(dict.files[i]);
+    wordCount += await registerDict(dict.files[i], dictionaryId);
     const progress = `${i + 1}/${dict.files.length}`;
     fnProgress(wordCount, progress);
   }
+  await storage.sync.set({ [KEY_DICTIONARY_ID]: dictionaryId + 1 });
   return wordCount;
 };
 
@@ -128,9 +137,13 @@ const loadJsonFile = async (fname: string): Promise<Record<string, any>> => {
   return response.json();
 };
 
-const registerDict = async (fname: string): Promise<number> => {
+const registerDict = async (fname: string, dictionaryId: number): Promise<number> => {
   const dictData = await loadJsonFile(fname);
-  const wordCount = Object.keys(dictData).length;
-  await storage.local.set(dictData);
+  const dictDataWithSuffix = {};
+  for (const [head, desc] of Object.entries(dictData)) {
+    dictDataWithSuffix[`${head}_${dictionaryId}`] = desc;
+  }
+  const wordCount = Object.keys(dictDataWithSuffix).length;
+  await storage.local.set(dictDataWithSuffix);
   return wordCount;
 };

--- a/src/options/resource/en.ts
+++ b/src/options/resource/en.ts
@@ -94,6 +94,8 @@ const EnglishTextResource: TextResource = {
     "This is JSON data which expresses the whole Mouse Dictionary's settings. Please use it for backup, sharing and so forth.",
   skipPdfConfirmation: "Skip PDF download confirmation",
   pdfUrlPattern: "Override PDF document judgment (regular expressions for URL)",
+  useMultipleDictionaries: "Show EN-EN and EN-JA dictionaries at the same time",
+  useMultipleDictionariesDescription: "You will need to reload all dictionary data.",
 };
 
 export { EnglishTextResource };

--- a/src/options/resource/ja.ts
+++ b/src/options/resource/ja.ts
@@ -88,6 +88,8 @@ const JapaneseTextResource: TextResource = {
   aboutJsonEditor: "Mouse Dictionary設定全体のJSONデータです。バックアップや共有にご利用ください ※辞書データは含みません",
   skipPdfConfirmation: "PDFファイルのダウンロード確認を省略する",
   pdfUrlPattern: "PDFドキュメント判定の上書き(URLに対する正規表現)",
+  useMultipleDictionaries: "英和・英英辞書を同時に表示する",
+  useMultipleDictionariesDescription: "すべての辞書データの再読み込みが必要となります",
 };
 
 export { JapaneseTextResource };

--- a/src/options/resource/types.ts
+++ b/src/options/resource/types.ts
@@ -78,6 +78,8 @@ export type TextResource = {
   aboutJsonEditor: string;
   skipPdfConfirmation: string;
   pdfUrlPattern: string;
+  useMultipleDictionaries: string;
+  useMultipleDictionariesDescription: string;
 };
 
 export type TextResourceKeys = keyof TextResource;

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -34,6 +34,7 @@ export type MouseDictionaryAdvancedSettings = {
   dialogTemplate: string;
   contentTemplate: string;
   pdfUrl: string;
+  useMultipleDictionaries: boolean;
 };
 
 export type MouseDictionarySettings = MouseDictionaryBasicSettings & MouseDictionaryAdvancedSettings;


### PR DESCRIPTION
#58 に対処します。

## 背景

辞書データは、見出し語を key、説明を value とする構造として保存されていますが、
同じ見出し語を持つ別の辞書データを登録したさいに、重複する key をもつものは新しい辞書データに置き換えられてしまっていました。

例えば EN -> JA 辞書登録のあとに EN -> EN 辞書を登録すると、両方に共通して存在する見出し語の説明には EN -> EN しか表示されませんでした。

## 対処法

- 辞書を登録するときに、登録順に辞書番号を振り、見出し語に suffix として辞書番号をつけたものを辞書データとして登録する
  - e.g. { "orange_0": "〈C〉『オレンジ』,柑橘(かんきつ)類...", "orange_1": "1. The fruit of a tree of the genus Citrus (C. Aurantium)..." }
  - 辞書番号は登録のたびに 1 ずつ加算して `storage.sync` に保存している
  - そのため同じデータを再登録しても別物として扱われて表示される 🤔 
- データを参照するときは、すべての辞書番号（0 から現在の辞書番号まで）の suffix をつけた見出し語（orange_1 など）で検索し、表示のときに suffix を除去する
  - 登録順に上から表示される

## 動作デモ

Windows 10, Chrome, デフォルトの辞書（[ejdict-hand](https://github.com/kujirahand/EJDict)）と [Webster](https://github.com/matthewreagan/WebstersEnglishDictionary) を登録した状態

![demo](https://user-images.githubusercontent.com/60635066/132987414-9cd1a30c-e74a-4ab8-bd72-478937b65e80.gif)

Debug build で Chrome と Firefox で動作することを確認しました。

個人的に欲しい機能だったので実装されたらうれしいなという気持ちで PR 出させていただきました…！ 🙏 