### PR TITLE
Adding github action for automated submission

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,29 @@
+name: Submit Chrome and Firefox
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        market: [chrome, firefox]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+      - name: Install Packages
+        run: npm install
+      - name: Build
+        run: |
+          npm run package-${{ matrix.market }}
+      - name: Submit artifact
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: mouse-dictionary-${{ matrix.market }}-{version}.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ dist-*/
 coverage/
 static_overwrite/
 static_pdf/
+
+keys.json


### PR DESCRIPTION
Hi @wtetsu!

My friend learning Japanese love this extension and recommended it to me. After using it for a while, I must say it's awesome! I thought about contributing and found that your project doesn't have automated archive submission yet. Thus, I created a github action incorporating [bpp](https://browser.market) that can submit the zip to the Chrome/Firefox stores automatically for you (I'm working on supporting Safari as well). It is set to run manually from the github action tab, but we can tweak it to run as frequent as you wish! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample keys for your project:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "abcd"
  }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)