### PR TITLE
Upgrade bpp to v2

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           npm run package-${{ matrix.market }}
       - name: Submit artifact
-        uses: plasmo-corp/bpp@v1
+        uses: PlasmoHQ/bpp@v2
         with:
           artifact: mouse-dictionary-${{ matrix.market }}-{version}.zip
           keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. We also renamed our organization which is why that's different now!

The new version adds support for the Edge Web Store Add-Ons API and improved reliability.


⚠️ Heads up the schema's changed a bit ⚠️

Here's an updated representation: https://raw.githubusercontent.com/PlasmoHQ/bpp/v2/keys.schema.json
Here's an example: https://github.com/PlasmoHQ/bpp/blob/main/keys.template.json