### PR TITLE
Add command to activate extension for Vivaldi

### DIFF
--- a/data/manifest/manifest-chrome.json
+++ b/data/manifest/manifest-chrome.json
@@ -26,6 +26,9 @@
     },
     "scroll_up": {
       "description": "__MSG_scrollUp__"
+    },
+    "activate_extension": {
+      "description": "Activate the extension (Workaround for Vivaldi)"
     }
   },
   "icons": {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -38,6 +38,12 @@ chrome.commands.onCommand.addListener((command) => {
     case "scroll_down":
       sendToActiveTab((tabId) => chrome.tabs.sendMessage(tabId, { message: { type: "scroll_down" } }));
       break;
+    case "activate_extension":
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ["main.js"],
+      });
+      break;
   }
 });
 


### PR DESCRIPTION
In Vivaldi, there's an issue where the _execute_action of Manifest V3 cannot be executed.
See: https://forum.vivaldi.net/topic/75247/extensions-keyboard-shortcuts-don-t-work/22

This pull request offers a solution to that problem. Specifically, it defines a new shortcut command that performs actions equivalent to _execute_action.

This change is intended for Vivaldi users, and ideally, we wouldn't want to merge such browser-specific modifications into the main codebase. However, repeatedly building locally to keep up with the updates of Mouse Dictionary is cumbersome...

What are your thoughts on this?